### PR TITLE
Resolved exit 126 error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,14 @@
 #
 
 # Pull base image.
-FROM dockerfile/ubuntu
+FROM ubuntu
+
+RUN apt-get update
 
 # Add files.
 ADD bin/rabbitmq-start /usr/local/bin/
+
+RUN apt-get install -y wget
 
 # Install RabbitMQ.
 RUN \


### PR DESCRIPTION
I had the following error on my Ubuntu 14.04 server running docker:
sh: 1: /usr/lib/rabbitmq/bin/rabbitmq-server: Permission denied

Both automatic build and manual (i.e. pull from Docker Hub and build from Dockerfile failed).
The changes I did resolved the issue for me.
