### PR TITLE
Limit file descriptors to avoid Erlang CPU bug

### DIFF
--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+ulimit -n 1024
 chown -R rabbitmq:rabbitmq /data
 rabbitmq-server $@


### PR DESCRIPTION
The rabbitmq container has a high open file limit, which causes Erlang to use up unnecessarily large amounts of CPU in the child_setup process.

See: http://erlang.org/pipermail/erlang-questions/2013-June/074205.html
And:  https://groups.google.com/forum/#!msg/rabbitmq-users/hO06SB-QBqc

This patch fixes the issue by setting the open file limit to 1024 via an extra ulimit instruction. In theory it should also be possible to set this via `/etc/security/limits.conf`, but I was unable to get this to work under Docker.
