### PR TITLE
Enabling Dynamic port Assignment for Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y rabbitmq-server && \
   rm -rf /var/lib/apt/lists/* && \
   rabbitmq-plugins enable rabbitmq_management && \
-  echo "[{rabbit, [{loopback_users, []},{tcp_listeners,[{'127.0.0.1',5672}]}]}, {rabbitmq_management, [{listener, [{port, 15672}]}]}]." > /etc/rabbitmq/rabbitmq.config && \
+  echo "[{rabbit, [{loopback_users, []},{tcp_listeners,[{5672}]}]}, {rabbitmq_management, [{listener, [{port, 15672}]}]}]." > /etc/rabbitmq/rabbitmq.config && \
   chmod +x /usr/local/bin/rabbitmq-start
 
 # Define environment variables.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   DEBIAN_FRONTEND=noninteractive apt-get install -y rabbitmq-server && \
   rm -rf /var/lib/apt/lists/* && \
   rabbitmq-plugins enable rabbitmq_management && \
-  echo "[{rabbit, [{loopback_users, []}]}]." > /etc/rabbitmq/rabbitmq.config && \
+  echo "[{rabbit, [{loopback_users, []},{tcp_listeners,[{'127.0.0.1',5672}]}]}, {rabbitmq_management, [{listener, [{port, 15672}]}]}]." > /etc/rabbitmq/rabbitmq.config && \
   chmod +x /usr/local/bin/rabbitmq-start
 
 # Define environment variables.
@@ -32,8 +32,8 @@ VOLUME ["/data/log", "/data/mnesia"]
 WORKDIR /data
 
 # Define default command.
-CMD ["rabbitmq-start"]
-
-# Expose ports.
+ENTRYPOINT ["rabbitmq-start"]
+CMD ["-p5672", "-h15672"]
 EXPOSE 5672
 EXPOSE 15672
+

--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -1,5 +1,16 @@
 #!/bin/bash
-
+PORT=5672
+HTTP_PORT=15672
+while getopts "p:h:" opts; do
+   case ${opts} in
+        h) HTTP_PORT=${OPTARG} ;;      
+	p) PORT=${OPTARG};;
+   esac
+done
+sed -i "s/15672/${HTTP_PORT}/g" /etc/rabbitmq/rabbitmq.config
+sed -i "s/5672/${PORT}/g" /etc/rabbitmq/rabbitmq.config
+echo "HTTP_PORT=$HTTP_PORT"
+echo "PORT=$PORT"
 ulimit -n 1024
 chown -R rabbitmq:rabbitmq /data
 rabbitmq-server $@


### PR DESCRIPTION
We wanted to be able to assign ports for the rabbit container to listen on, so that multiple rabbitmq containers could be run on the same machine. We used the rabbitmq.config file properties and the start script to enable this.
We kept backward compatibility so that existing uses of the image will not be broken in any way.
Would love your review and feedback.
@pilwon would appreciate your comments, even if this isn't good for you, so we know to move forward and fork...
