### PR TITLE
Retrieve the RabbitMQ repo signing key over SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ADD bin/rabbitmq-start /usr/local/bin/
 
 # Install RabbitMQ.
 RUN \
-  wget -qO - http://www.rabbitmq.com/rabbitmq-signing-key-public.asc | apt-key add - && \
+  wget -qO - https://www.rabbitmq.com/rabbitmq-signing-key-public.asc | apt-key add - && \
   echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y rabbitmq-server && \


### PR DESCRIPTION
www.rabbitmq.com supports SSL, so retrieving the key over SSL may be beneficial here. 
