### PR TITLE
Remove bash from process tree

### DIFF
--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -2,4 +2,4 @@
 
 ulimit -n 1024
 chown -R rabbitmq:rabbitmq /data
-rabbitmq-server $@
+exec rabbitmq-server $@


### PR DESCRIPTION
Current implementation is failing to stop because bash is the parent process of rabbitmq and failed to transmit signals, using exec rabbitmq-server should become the top process and correct handled all signals sends by docker.
