### PR TITLE
Fix #10

### DIFF
--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -6,7 +6,7 @@
 # wont reach rabbitmq. This ends up timing out on the Docker-side
 # for default 10 seconds, till we (the container) is getting killed.
 # We need to trap SIGTERM to handle this.
-PID=; trap '[[ ${PID} ]] && /usr/sbin/rabbitmqctl stop; exit 0' SIGTERM
+PID=; trap '[[ ${PID} ]] && /usr/sbin/rabbitmqctl stop; exit 0' SIGTERM SIGINT
 
 ulimit -n 1024
 chown -R rabbitmq:rabbitmq /data

--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# rabbitmq-server is in itself a shell script that doesnt
+# use exec (ie, it wont replace init 1 with rabbitmq itself).
+# Docker sends its stop signal to the containers init 1, which
+# wont reach rabbitmq. This ends up timing out on the Docker-side
+# for default 10 seconds, till we (the container) is getting killed.
+# We need to trap SIGTERM to handle this.
+PID=; trap '[[ ${PID} ]] && /usr/sbin/rabbitmqctl stop; exit 0' SIGTERM
+
 ulimit -n 1024
 chown -R rabbitmq:rabbitmq /data
-exec rabbitmq-server $@
+rabbitmq-server $@ & PID=$!
+
+# Dont exit this script since we would loose our SIGTERM trap
+wait


### PR DESCRIPTION
Fixes the problem by letting our own startup script handle the signal and cleanly shuts down rabbitmq with the rabbitmqctl command.
