### PR TITLE
rabbitmq-server as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   rabbitmq-plugins enable rabbitmq_management && \
   echo "[{rabbit, [{loopback_users, []}]}]." > /etc/rabbitmq/rabbitmq.config && \
-  ulimit -n 1024 && \
-  chown -R rabbitmq:rabbitmq /data
+  ulimit -n 1024
 
 # Define environment variables.
 ENV RABBITMQ_LOG_BASE /data/log
@@ -28,6 +27,7 @@ ENV RABBITMQ_MNESIA_BASE /data/mnesia
 
 # Define mount points.
 VOLUME ["/data/log", "/data/mnesia"]
+RUN chown -R rabbitmq:rabbitmq /data
 
 # Define working directory.
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   rabbitmq-plugins enable rabbitmq_management && \
   echo "[{rabbit, [{loopback_users, []}]}]." > /etc/rabbitmq/rabbitmq.config && \
-  chmod +x /usr/local/bin/rabbitmq-start
+  ulimit -n 1024 && \
+  chown -R rabbitmq:rabbitmq /data
 
 # Define environment variables.
 ENV RABBITMQ_LOG_BASE /data/log
@@ -32,7 +33,7 @@ VOLUME ["/data/log", "/data/mnesia"]
 WORKDIR /data
 
 # Define default command.
-CMD ["rabbitmq-start"]
+CMD ["/usr/sbin/rabbitmq-server"]
 
 # Expose ports.
 EXPOSE 5672

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ FROM dockerfile/ubuntu
 # Add files.
 ADD bin/rabbitmq-start /usr/local/bin/
 
-# Install RabbitMQ.
+# Install RabbitMQ. Explicitly create data directories with rabbitmq as owner.
+# See http://stackoverflow.com/questions/26145351/why-doesnt-chown-work-in-dockerfile.
 RUN \
   wget -qO - https://www.rabbitmq.com/rabbitmq-signing-key-public.asc | apt-key add - && \
   echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list && \
@@ -19,7 +20,10 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   rabbitmq-plugins enable rabbitmq_management && \
   echo "[{rabbit, [{loopback_users, []}]}]." > /etc/rabbitmq/rabbitmq.config && \
-  ulimit -n 1024
+  ulimit -n 1024 && \
+  mkdir -p /data/log && \
+  mkdir -p /data/mnesia && \
+  chown -R rabbitmq:rabbitmq /data
 
 # Define environment variables.
 ENV RABBITMQ_LOG_BASE /data/log
@@ -27,13 +31,12 @@ ENV RABBITMQ_MNESIA_BASE /data/mnesia
 
 # Define mount points.
 VOLUME ["/data/log", "/data/mnesia"]
-RUN chown -R rabbitmq:rabbitmq /data
 
 # Define working directory.
 WORKDIR /data
 
 # Define default command.
-CMD ["/usr/sbin/rabbitmq-server"]
+ENTRYPOINT /usr/sbin/rabbitmq-server
 
 # Expose ports.
 EXPOSE 5672

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@
 # Pull base image.
 FROM dockerfile/ubuntu
 
-# Add files.
-ADD bin/rabbitmq-start /usr/local/bin/
-
 # Install RabbitMQ. Explicitly create data directories with rabbitmq as owner.
 # See http://stackoverflow.com/questions/26145351/why-doesnt-chown-work-in-dockerfile.
 RUN \

--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-ulimit -n 1024
-chown -R rabbitmq:rabbitmq /data
-rabbitmq-server $@

--- a/bin/rabbitmq-start
+++ b/bin/rabbitmq-start
@@ -2,4 +2,4 @@
 
 ulimit -n 1024
 chown -R rabbitmq:rabbitmq /data
-exec rabbitmq-server $@
+rabbitmq-server $@


### PR DESCRIPTION
Addresses https://github.com/dockerfile/rabbitmq/issues/14 by making Rabbit the entrypoint.

There still appears to be an issue sending SIGTERM to Rabbit, but I believe that's currently the case with exec, too.

This may be a little heavy-handed, but it's what got things working for me.
